### PR TITLE
Check and optimize ui for mobile

### DIFF
--- a/src/components/Toolbar/MeasurementToolbar.tsx
+++ b/src/components/Toolbar/MeasurementToolbar.tsx
@@ -47,6 +47,11 @@ interface MeasurementToolbarProps {
   onSnappingChange?: (enabled: boolean) => void;
   sidebarOpen?: boolean;
   onSidebarOpenChange?: (open: boolean) => void;
+  // Mobile controls (optional, allow external control of sheet and section)
+  mobileOpen?: boolean;
+  onMobileOpenChange?: (open: boolean) => void;
+  section?: 'tools' | 'layers' | 'ai' | 'info';
+  onSectionChange?: (section: 'tools' | 'layers' | 'ai' | 'info') => void;
 }
 
 const MeasurementToolbar: React.FC<MeasurementToolbarProps> = ({
@@ -66,9 +71,24 @@ const MeasurementToolbar: React.FC<MeasurementToolbarProps> = ({
   onSnappingChange,
   sidebarOpen,
   onSidebarOpenChange,
+  mobileOpen,
+  onMobileOpenChange,
+  section,
+  onSectionChange,
 }) => {
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-  const [activeSection, setActiveSection] = useState<'tools' | 'layers' | 'ai' | 'info'>('tools');
+  const [internalMobileOpen, setInternalMobileOpen] = useState(false);
+  const isMobileMenuOpen = typeof mobileOpen === 'boolean' ? mobileOpen : internalMobileOpen;
+  const setMobileOpen = (open: boolean) => {
+    if (onMobileOpenChange) onMobileOpenChange(open);
+    else setInternalMobileOpen(open);
+  };
+
+  const [internalSection, setInternalSection] = useState<'tools' | 'layers' | 'ai' | 'info'>('tools');
+  const activeSection = section ?? internalSection;
+  const setActiveSection = (value: 'tools' | 'layers' | 'ai' | 'info') => {
+    if (onSectionChange) onSectionChange(value);
+    else setInternalSection(value);
+  };
   const isSidebarOpen = !!sidebarOpen;
 
   type TabId = 'tools' | 'layers' | 'ai' | 'info';


### PR DESCRIPTION
Add controlled props to `MeasurementToolbar` to enable external management of its mobile sheet and active section, facilitating mobile navigation optimization.

This change converts the `isMobileMenuOpen` and `activeSection` states within `MeasurementToolbar` to be externally controllable. This is a prerequisite for integrating a new `MobileBottomNav` component, allowing it to dictate the toolbar's mobile behavior (e.g., opening the tool sheet, switching sections) and centralize mobile navigation control.

---
<a href="https://cursor.com/background-agent?bcId=bc-7920b81d-3732-4146-9dbe-6a8a9097b047">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7920b81d-3732-4146-9dbe-6a8a9097b047">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

