### PR TITLE
Configure supabase anon key in environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
+VITE_SUPABASE_URL="https://YOUR_PROJECT_ID.supabase.co"
+VITE_SUPABASE_ANON_KEY="YOUR_ANON_PUBLIC_KEY"
+
+# Optional server-side only variables (never expose in client code)
+# STRIPE_SECRET_KEY="sk_live_or_test_..."
+# STRIPE_WEBHOOK_SECRET="whsec_..."
+# SUPABASE_SERVICE_ROLE="service_role_secret_key"
+# SUPABASE_URL="https://YOUR_PROJECT_ID.supabase.co"
 # Frontend
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=

--- a/api/stripe-webhook.ts
+++ b/api/stripe-webhook.ts
@@ -5,7 +5,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (req.method !== 'POST') return res.status(405).send('Method Not Allowed');
     const secret = process.env.STRIPE_SECRET_KEY;
     const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE;
-    const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
     if (!secret || !supabaseServiceKey || !supabaseUrl) {
       return res.status(202).send('Webhook not configured');
     }

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -1,13 +1,21 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = (import.meta as any).env?.VITE_SUPABASE_URL as string;
-const SUPABASE_PUBLISHABLE_KEY = (import.meta as any).env?.VITE_SUPABASE_ANON_KEY as string;
+const SUPABASE_URL = (import.meta as any).env?.VITE_SUPABASE_URL as string | undefined;
+const SUPABASE_PUBLISHABLE_KEY = (import.meta as any).env?.VITE_SUPABASE_ANON_KEY as string | undefined;
+
+if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) {
+  const missing = [
+    !SUPABASE_URL ? 'VITE_SUPABASE_URL' : undefined,
+    !SUPABASE_PUBLISHABLE_KEY ? 'VITE_SUPABASE_ANON_KEY' : undefined,
+  ].filter(Boolean).join(', ');
+  throw new Error(`Supabase configuration missing: ${missing}. Please set these in your .env file.`);
+}
 
 export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, {
-  auth: {
-    storage: typeof window !== 'undefined' ? localStorage : undefined,
-    persistSession: true,
-    autoRefreshToken: true,
-  }
+	auth: {
+		storage: typeof window !== 'undefined' ? localStorage : undefined,
+		persistSession: true,
+		autoRefreshToken: true,
+	}
 });


### PR DESCRIPTION
Harden Supabase client initialization to require environment variables and add an `.env.example` to guide setup.

The original error indicated missing Supabase API keys. This PR ensures the client explicitly checks for these keys and provides a clear `.env.example` for proper configuration, preventing runtime errors and guiding developers. It also improves the Stripe webhook's ability to find the Supabase URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-22fc51c4-abd1-4905-96a8-b29822cb6b4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-22fc51c4-abd1-4905-96a8-b29822cb6b4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

